### PR TITLE
Only send the message if there is a message

### DIFF
--- a/plugin.py
+++ b/plugin.py
@@ -128,11 +128,12 @@ class WebhookPlugin(Plugin):
         if isinstance(message, Response):
             return message
 
-        self.log.info(f"Sending message to room {room}: {message}")
-        try:
-            await (self.client.send_markdown if self.config["markdown"] else self.client.send_text)(room, message)
-        except Exception as e:
-            error_message = f"Failed to send message '{message}' to room {room}: {e}"
-            self.log.error(error_message)
-            return Response(status=500, text=error_message)
-        return Response()
+        if message:
+            self.log.info(f"Sending message to room {room}: {message}")
+            try:
+                await (self.client.send_markdown if self.config["markdown"] else self.client.send_text)(room, message)
+            except Exception as e:
+                error_message = f"Failed to send message '{message}' to room {room}: {e}"
+                self.log.error(error_message)
+                return Response(status=500, text=error_message)
+            return Response()


### PR DESCRIPTION
Previously if the template you provided ended in a blank message, the plugin would still send the blank message through. Now if the template results in a blank message, the response is not sent trough to matrix. This allows filtering of messages from a noisy webhook in the template.