### PR TITLE
Only send the message if there is a message

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,10 @@ Otherwise it will be sent as Markdown.
 ### `force_json`
 This setting takes a boolean and specifies whether the request body should be interpreted and parsed as json, even if the content type says otherwise.
 
+### `ignore_empty_messages`
+This setting takes a boolean and specifies whether a message should be sent if the message is empty. If `false` (the default) a message will be send for every
+successful message consumed by the webhook. If `true` if the template generates an empty message, no message is sent to the matrix client.  
+
 
 
 ## Formatting

--- a/base-config.yaml
+++ b/base-config.yaml
@@ -6,3 +6,4 @@ auth_type:
 auth_token:
 markdown: false
 force_json: false
+ignore_empty_messages: false

--- a/plugin.py
+++ b/plugin.py
@@ -54,6 +54,7 @@ class Config(BaseProxyConfig):
         helper.copy("auth_token")
         helper.copy("markdown")
         helper.copy("force_json")
+        helper.copy("ignore_empty_messages")
 
 
 class WebhookPlugin(Plugin):
@@ -127,6 +128,11 @@ class WebhookPlugin(Plugin):
             return room
         if isinstance(message, Response):
             return message
+
+        if self.config["ignore_empty_messages"] and not message:
+            self.log.info(f"Not Sending message to room. {req} was successfully processed, "
+                          f"but the template generated an empty message.")
+            return Response()
 
         self.log.info(f"Sending message to room {room}: {message}")
         try:


### PR DESCRIPTION
Previously if the template you provided ended in a blank message, the plugin would still send the blank message through. Now if the template results in a blank message, the response is not sent trough to matrix. This allows filtering of messages from a noisy webhook in the template.