### PR TITLE
Added option to set msgtype for messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,12 @@ The format the message is interpreted as. Must be one of:
 - `html`
 
 
+### `message_type`
+The type the message is sent as. Must be one of:
+- `m.text` (default)
+- `m.notice`
+
+
 ### `auth_type`
 This can be used to protect a webhook against unauthorized access.
 Can be one of `Basic` for HTTP basic auth with username and password or `Bearer` for bearer token auth.

--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ message: |
     - {{ text }}
     {% endfor %}
 message_format: markdown
+message_type: m.text
 auth_type: Basic
 auth_token: abc:123
 force_json: false

--- a/base-config.yaml
+++ b/base-config.yaml
@@ -3,6 +3,7 @@ method: "POST"
 room: "!AAAAAAAAAAAAAAAAAA:example.com"
 message: "Hello world!"
 message_format: "plaintext"
+message_type: "m.text"
 auth_type:
 auth_token:
 force_json: false

--- a/maubot.yaml
+++ b/maubot.yaml
@@ -1,6 +1,6 @@
 maubot: 0.3.1
 id: me.jkhsjdhjs.maubot.webhook
-version: 0.4.0
+version: 0.3.0
 license: AGPL-3.0-or-later
 modules:
   - plugin

--- a/maubot.yaml
+++ b/maubot.yaml
@@ -1,6 +1,6 @@
 maubot: 0.3.1
 id: me.jkhsjdhjs.maubot.webhook
-version: 0.3.0
+version: 0.4.0
 license: AGPL-3.0-or-later
 modules:
   - plugin


### PR DESCRIPTION
Added config option to send messages as type m.text (normal message / default) or m.notice (bot message).

In my tests it worked without any problems, but I may have overlooked a few things.

Thanks for this great and simple plugin!